### PR TITLE
No RefCells

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,6 +1,26 @@
 use RegT;
 use CTC;
 
+
+#[allow(unused_variables)]
+pub trait CpuBus {
+    /// CPU reads from I/O port
+    fn cpu_inp(&mut self, port: RegT) -> RegT {
+        0
+    }
+    /// CPU writes to I/O port
+    fn cpu_outp(&mut self, port: RegT, val: RegT) {}
+
+    /// request an interrupt, called by a device to generate interrupt
+    fn irq(&mut self, ctrl_id: usize, vec: u8) {}
+    /// interrupt request acknowledge (called by CPU), return interrupt vector
+    fn irq_ack(&mut self) -> RegT {
+        0
+    }
+    /// notify interrupt daisy chain that CPU executed a RETI
+    fn irq_reti(&mut self) {}
+}
+
 /// system bus trait
 ///
 /// The system bus must be implemented by the higher level parts
@@ -11,39 +31,23 @@ use CTC;
 /// trait functions will be called.
 #[allow(unused_variables)]
 pub trait Bus {
-    /// CPU reads from I/O port
-    fn cpu_inp(&self, port: RegT) -> RegT {
-        0
-    }
-    /// CPU writes to I/O port
-    fn cpu_outp(&self, port: RegT, val: RegT) {}
-
-    /// request an interrupt, called by a device to generate interrupt
-    fn irq(&self, ctrl_id: usize, vec: u8) {}
     /// forward an interrupt-request to CPU, called by daisychain
-    fn irq_cpu(&self) {}
-    /// interrupt request acknowledge (called by CPU), return interrupt vector
-    fn irq_ack(&self) -> RegT {
-        0
-    }
-    /// notify interrupt daisy chain that CPU executed a RETI
-    fn irq_reti(&self) {}
-
+    fn irq_cpu(&mut self) {}
     /// PIO output callback
-    fn pio_outp(&self, pio: usize, chn: usize, data: RegT) {}
+    fn pio_outp(&mut self, pio: usize, chn: usize, data: RegT) {}
     /// PIO input callback
-    fn pio_inp(&self, pio: usize, chn: usize) -> RegT {
+    fn pio_inp(&mut self, pio: usize, chn: usize) -> RegT {
         0
     }
     /// PIO channel rdy line has changed
-    fn pio_rdy(&self, pio: usize, chn: usize, rdy: bool) {}
+    fn pio_rdy(&mut self, pio: usize, chn: usize, rdy: bool) {}
     /// interrupt request from PIO
-    fn pio_irq(&self, pio: usize, chn: usize, int_vector: RegT) {}
+    fn pio_irq(&mut self, pio: usize, chn: usize, int_vector: RegT) {}
 
     /// CTC write callback
-    fn ctc_write(&self, chn: usize, ctc: &CTC) {}
+    fn ctc_write(&mut self, chn: usize, ctc: &CTC) {}
     /// CTC counter/timer reached zero
-    fn ctc_zero(&self, chn: usize, ctc: &CTC) {}
+    fn ctc_zero(&mut self, chn: usize, ctc: &CTC) {}
     /// interrupt request from CTC
-    fn ctc_irq(&self, ctc: usize, chn: usize, int_vector: RegT) {}
+    fn ctc_irq(&mut self, ctc: usize, chn: usize, int_vector: RegT) {}
 }

--- a/src/ctc.rs
+++ b/src/ctc.rs
@@ -80,7 +80,7 @@ impl CTC {
     }
 
     /// write a CTC control register
-    pub fn write(&mut self, bus: &Bus, chn: usize, val: RegT) {
+    pub fn write(&mut self, bus: &mut Bus, chn: usize, val: RegT) {
         let mut notify_bus = false;
         let old_ctrl = self.chn[chn].control;
         let new_ctrl = val as u8;
@@ -126,7 +126,7 @@ impl CTC {
     }
 
     /// externally provided trigger/pulse signal, updates counters
-    pub fn trigger(&mut self, bus: &Bus, chn: usize) {
+    pub fn trigger(&mut self, bus: &mut Bus, chn: usize) {
         let ctrl = self.chn[chn].control;
         if (ctrl & (CTC_RESET | CTC_CONSTANT_FOLLOWS)) == 0 {
             self.chn[chn].down_counter -= 1;
@@ -140,7 +140,7 @@ impl CTC {
 
     /// update the CTC channel timers
     #[inline(always)]
-    pub fn update_timers(&mut self, bus: &Bus, cycles: i64) {
+    pub fn update_timers(&mut self, bus: &mut Bus, cycles: i64) {
         for chn in 0..NUM_CHANNELS {
             let ctrl = self.chn[chn].control;
             let waiting = self.chn[chn].waiting_for_trigger;
@@ -179,7 +179,7 @@ impl CTC {
     }
 
     /// trigger interrupt and/or callback when downcounter reaches 0
-    fn down_counter_trigger(&self, bus: &Bus, chn: usize) {
+    fn down_counter_trigger(&self, bus: &mut Bus, chn: usize) {
         if (self.chn[chn].control & CTC_INTERRUPT_BIT) == CTC_INTERRUPT_ENABLED {
             bus.ctc_irq(self.id, chn, self.chn[chn].int_vector as RegT);
         }

--- a/src/daisychain.rs
+++ b/src/daisychain.rs
@@ -54,7 +54,7 @@ impl Daisychain {
     }
 
     /// request an interrupt from an interrupt controller, called by bus
-    pub fn irq(&mut self, bus: &Bus, ctrl_id: usize, vec: u8) {
+    pub fn irq(&mut self, bus: &mut Bus, ctrl_id: usize, vec: u8) {
         if self.ctrl[ctrl_id].int_enabled {
             {
                 let ctrl = &mut self.ctrl[ctrl_id];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod daisychain;
 pub use registers::{Registers, CF, NF, VF, PF, XF, HF, YF, ZF, SF};
 pub use memory::Memory;
 pub use cpu::CPU;
-pub use bus::Bus;
+pub use bus::{Bus, CpuBus};
 pub use pio::{PIO, PIO_A, PIO_B};
 pub use ctc::{CTC, CTC_0, CTC_1, CTC_2, CTC_3};
 pub use daisychain::Daisychain;

--- a/src/pio.rs
+++ b/src/pio.rs
@@ -147,7 +147,7 @@ impl PIO {
     }
 
     /// set rdy flag on channel, and call pio_rdy callback on bus if changed
-    fn set_rdy(&mut self, bus: &Bus, chn: usize, rdy: bool) {
+    fn set_rdy(&mut self, bus: &mut Bus, chn: usize, rdy: bool) {
         let c = &mut self.chn[chn];
         if c.rdy != rdy {
             c.rdy = rdy;
@@ -156,7 +156,7 @@ impl PIO {
     }
 
     /// write data to PIO channel
-    pub fn write_data(&mut self, bus: &Bus, chn: usize, data: RegT) {
+    pub fn write_data(&mut self, bus: &mut Bus, chn: usize, data: RegT) {
         match self.chn[chn].mode {
             Mode::Output => {
                 self.set_rdy(bus, chn, false);
@@ -183,7 +183,7 @@ impl PIO {
     }
 
     /// read data from PIO channel
-    pub fn read_data(&mut self, bus: &Bus, chn: usize) -> RegT {
+    pub fn read_data(&mut self, bus: &mut Bus, chn: usize) -> RegT {
         match self.chn[chn].mode {
             Mode::Output => self.chn[chn].output as RegT,
             Mode::Input => {
@@ -208,7 +208,7 @@ impl PIO {
     }
 
     /// write data from peripheral device into PIO
-    pub fn write(&mut self, bus: &Bus, chn: usize, data: RegT) {
+    pub fn write(&mut self, bus: &mut Bus, chn: usize, data: RegT) {
         let mut c = self.chn[chn];
         if c.mode == Mode::Bitcontrol {
             c.input = data as u8;


### PR DESCRIPTION
Hi! I've got intrigued by the discussion at https://users.rust-lang.org/t/modeling-embedded-hardware-in-rust-and-how-to-have-multiple-mutable-references-cleanly/6761 and here are my experiments. 

I don't intend to merge this, the PR is just a convenient medium to discuss code. 

So with a little bit of tweaking I've managed to run z1013 example without resorting to RefCells :) 

The idea is to carefully layer `Bus` traits and its implementators. I think that no matter how many devices are there on a particular board, such layering should always be possible, because there should be no cycles in device communications. 

Not sure if it makes any sense at all :) 