### PR TITLE
In examples, allocate the frame buffer on the heap

### DIFF
--- a/examples/kc87.rs
+++ b/examples/kc87.rs
@@ -220,7 +220,7 @@ fn main() {
 
     // the pixel frame buffer, written by System::decode_framebuffer()
     // and transfered to the minifb window
-    let mut frame_buffer = [0u32; WIDTH*HEIGHT];
+    let mut frame_buffer = vec![0u32; WIDTH*HEIGHT];
 
     let mut system = System::new();
     system.poweron();

--- a/examples/z1013.rs
+++ b/examples/z1013.rs
@@ -365,7 +365,7 @@ fn main() {
 
     // the pixel frame buffer, written by System::decode_framebuffer()
     // and transfered to the minifb window
-    let mut frame_buffer = [0u32; WIDTH*HEIGHT];
+    let mut frame_buffer = vec![0u32; WIDTH*HEIGHT];
     
     // spin up the emulator and run the main loop
     let mut system = System::new();


### PR DESCRIPTION
This change fixes a stack overflow on macOS.